### PR TITLE
Refactor RobotsTxt.php to correctly generate the Sitemap URLs by appending a forward slash before each sitemap path.

### DIFF
--- a/.github/workflows/open-ai-pr-description.yml
+++ b/.github/workflows/open-ai-pr-description.yml
@@ -15,7 +15,7 @@ jobs:
   openai-pr-description:
     runs-on: ubuntu-22.04
     # Run the job only if the actor is NOT Dependabot
-    if: ${{ !startsWith(github.actor, 'dependabot') }
+    if: ${{ !startsWith(github.actor, 'dependabot') }}
     steps:
       - uses: platisd/openai-pr-description@master
         with:

--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -88,7 +88,7 @@ class RobotsTxt
         $sitemaps = Config::get('robots-txt.sitemap', []);
 
         foreach ($sitemaps as $sitemap) {
-            $txt .= 'Sitemap: '.$appUrl."/"."$sitemap\n";
+            $txt .= 'Sitemap: '.$appUrl.'/'."$sitemap\n";
         }
 
         return $txt;

--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -65,7 +65,7 @@ class RobotsTxt
     public function generate(): string
     {
         $appEnv = Config::get('app.env');
-        $appUrl = Config::get('app.url');
+        $appUrl = rtrim(Config::get('app.url'), '/');
 
         if ($appEnv !== 'production') {
             return "User-agent: *\nDisallow: /";
@@ -88,7 +88,7 @@ class RobotsTxt
         $sitemaps = Config::get('robots-txt.sitemap', []);
 
         foreach ($sitemaps as $sitemap) {
-            $txt .= 'Sitemap: '.$appUrl."$sitemap\n";
+            $txt .= 'Sitemap: '.$appUrl."/"."$sitemap\n";
         }
 
         return $txt;

--- a/tests/Feature/RobotsTxtEnvironmentTest.php
+++ b/tests/Feature/RobotsTxtEnvironmentTest.php
@@ -76,7 +76,7 @@ class RobotsTxtEnvironmentTest extends TestCase
 
         $sitemaps = config('robots-txt.sitemap');
         foreach ($sitemaps as $sitemapPath) {
-            $response->assertSee('Sitemap: '.($baseUrl).$sitemapPath);
+            $response->assertSee('Sitemap: '.($baseUrl).'/'.$sitemapPath);
         }
     }
 }

--- a/tests/Feature/RobotsTxtSitemapTest.php
+++ b/tests/Feature/RobotsTxtSitemapTest.php
@@ -25,7 +25,7 @@ class RobotsTxtSitemapTest extends TestCase
 
         $baseUrl = config('app.url');
 
-        $this->assertStringContainsString('Sitemap: '.$baseUrl.'sitemap.xml', $robotsContent);
+        $this->assertStringContainsString('Sitemap: '.$baseUrl.'/'.'sitemap.xml', $robotsContent);
     }
 
     /**
@@ -48,8 +48,8 @@ class RobotsTxtSitemapTest extends TestCase
 
         $baseUrl = config('app.url');
 
-        $this->assertStringContainsString('Sitemap: '.$baseUrl.'sitemap.xml', $robotsContent);
-        $this->assertStringContainsString('Sitemap: '.$baseUrl.'sitemap_pages.xml', $robotsContent);
-        $this->assertStringContainsString('Sitemap: '.$baseUrl.'sitemap_posts.xml', $robotsContent);
+        $this->assertStringContainsString('Sitemap: '.$baseUrl.'/'.'sitemap.xml', $robotsContent);
+        $this->assertStringContainsString('Sitemap: '.$baseUrl.'/'.'sitemap_pages.xml', $robotsContent);
+        $this->assertStringContainsString('Sitemap: '.$baseUrl.'/'.'sitemap_posts.xml', $robotsContent);
     }
 }


### PR DESCRIPTION
### Pull Request Description

This pull request refactors the `RobotsTxt.php` file to ensure that the generated Sitemap URLs are correctly formatted by appending a forward slash before each sitemap path. 

#### Motivation
The current implementation does not consistently include a leading slash in the Sitemap URLs, which can lead to malformed URLs in the `robots.txt` file. This inconsistency can negatively impact search engine crawling and indexing, potentially reducing the visibility of the site's content. 

#### Changes Made
- Updated the `generate()` method in `RobotsTxt.php` to use `rtrim()` on the application URL to remove any trailing slashes.
- Ensured that each sitemap path is preceded by a forward slash when constructing the Sitemap URLs.
- Adjusted the corresponding tests to verify that the Sitemap URLs are correctly formatted.

#### Benefits
By making these changes, we improve the reliability of the Sitemap URLs generated in the `robots.txt` file. This refinement enhances our SEO efforts and ensures that search engines can correctly access and index all site content, ultimately contributing to better site performance in search results.